### PR TITLE
[개발환경설정] 도커 컨테이너 밖에서 flyway 명령어를 사용할 수 있도록 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "migrate:prod": "node src/sqls/index.mjs prod",
     "migrate:dev": "node src/sqls/index.mjs dev",
     "migrate:clean": "node src/sqls/index.mjs clean",
+    "flyway:init:prod": "docker exec -it $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:prod",
+    "flyway:init:dev": "docker exec -it $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:dev",
+    "flyway:clean": "docker exec -it $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:clean",
     "lint": "next lint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "migrate:prod": "node src/sqls/index.mjs prod",
     "migrate:dev": "node src/sqls/index.mjs dev",
     "migrate:clean": "node src/sqls/index.mjs clean",
-    "flyway:init:prod": "docker exec -it $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:prod",
-    "flyway:init:dev": "docker exec -it $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:dev",
-    "flyway:clean": "docker exec -it $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:clean",
+    "flyway:init:prod": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:prod",
+    "flyway:init:dev": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:dev",
+    "flyway:clean": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:clean",
     "lint": "next lint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,9 @@
     "dev": "next dev -p 3600",
     "build": "next build",
     "start": "next start",
-    "migrate:prod": "node src/sqls/index.mjs prod",
-    "migrate:dev": "node src/sqls/index.mjs dev",
-    "migrate:clean": "node src/sqls/index.mjs clean",
-    "flyway:init:prod": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:prod",
-    "flyway:init:dev": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:dev",
-    "flyway:clean": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:clean",
+    "migrate:init:prod": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') node src/sqls/index.mjs prod",
+    "migrate:init:dev": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') node src/sqls/index.mjs dev",
+    "migrate:clean": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') node src/sqls/index.mjs clean",
     "lint": "next lint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "dev": "next dev -p 3600",
     "build": "next build",
     "start": "next start",
-    "migrate:init:prod": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') node src/sqls/index.mjs prod",
-    "migrate:init:dev": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') node src/sqls/index.mjs dev",
-    "migrate:clean": "docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') node src/sqls/index.mjs clean",
+    "migrate:init:prod": "docker exec MDGround3-service node src/sqls/index.mjs prod",
+    "migrate:init:dev": "docker exec MDGround3-service node src/sqls/index.mjs dev",
+    "migrate:clean": "docker exec MDGround3-service node src/sqls/index.mjs clean",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
# 이슈


* #53 

# 설명

```sh
# 1. 먼저 `docker ps` 명령어를 실행하여 컨테이너 이름이 **MDGround3-service**인 것을 가져와서 ID 컬럼만 추출 후 변수로 만들어준다.
$ $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}')

# 2. `docker exec <container-id>` 명령어를 실행하여 docker 컨테이너에 접속 후, flyway를 실행시켜준다.
$ docker exec $(docker ps --filter 'name=MDGround3-service' --format '{{.ID}}') npm run migrate:dev
```