### PR TITLE
[개발환경설정] 새로운 패키지 추가 시, 호스트 머신과 컨테이너의 node_modules가 동기화 되도록 개선

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,6 @@ services:
     working_dir: /usr/src/app
     volumes:
       - .:/usr/src/app
-      - "/usr/src/app/node_modules"
-      - "/usr/src/app/.next"
 
   mysql:
     container_name: MDGround3-db


### PR DESCRIPTION
# 이슈

* #58 

# 설명

* [Docker volume 정리](https://github.com/woogieReal/MDGround3/wiki/%5BDocker%5D-Volume)

```diff
// docker-compose.yaml

volumes:
     - .:/usr/src/app # 정리한 문서의 data 유지 방법 중 두 번째 경우에 해당 ... (1)
-    - "/usr/src/app/node_modules" # 정리한 문서의 data 유지 방법 중 첫 번째 경우에 해당 ... (2)
-    - "/usr/src/app/.next" # 정리한 문서의 data 유지 방법 중 첫 번째 경우에 해당 ... (3)
```

* (1)은 **bind mount의 경우**로 `docker-compose up -d` 명령어를 실행하는 디렉토리의 하위 파일들이 변경이 되었을 때, 컨테이너의 `/usr/src/app`에도 똑같이 반영됨(반대의 경우에도 마찬가지). 즉, 컨테이너의 `/usr/src/app`는 현재 작업중인 디렉토리를 바라보게 됨(or mapping 된다고 표현함)
* (2)와 (3)은 **호스트 머신의 특정 volume을 지정하지 않은 경우**로 호스트 머신의 `/var/lib/docker/volumes` 경로에 도커가 자동 생성한 해쉬 디렉토리를 바라보게 됨(or mapping 됨)
* 예를 들어, 기존의 경우(즉, (2)와 (3)이 제거되지 않고 그대로 적용되어 있는 경우)에 컨테이너의 `/usr/src/app/node_modules`는 호스트 머신의 `./node_modules`를 바라보고 있지 않고 `/var/lib/docker/volumes/qasd1klhvzix189aghv`를 바라보고 있으므로 `npm install classnames` 명령어를 실행했을 때, 호스트 머신의 `./node_modules` 에는 classnames 패키지가 설치되었지만, `/var/lib/docker/volumes/qasd1klhvzix189aghv`에는 classnames가 설치되지 않았으므로 "_classnames 패키지가 존재하지 않습니다_"라는 에러가 발생함