### PR TITLE
[트리] 트리섹션 root에서 우클릭시 클릭 위치에 따라 컨텍스트 메뉴 나오도록 개선

### DIFF
--- a/components/tree/modules/recursivTreeItem.tsx
+++ b/components/tree/modules/recursivTreeItem.tsx
@@ -21,7 +21,7 @@ interface Props {
   setTrees: Dispatch<SetStateAction<Tree[]>>
   setMethodType: Dispatch<SetStateAction<MethodTypeForRecursivTreeItem>>
   setMethodTargetTree: Dispatch<SetStateAction<Tree>>
-  setContextEvent: Dispatch<SetStateAction<React.BaseSyntheticEvent | null>>
+  setContextEvent: Dispatch<SetStateAction<React.BaseSyntheticEvent<MouseEvent> | null>>
 }
 const RecursivTreeItem = ({ treeItem, sameDepthTreeNames, setTrees, setMethodType, setMethodTargetTree, setContextEvent }: Props) => {
   const [treeData, setTreeData] = useState<Tree>(treeItem);
@@ -54,7 +54,7 @@ const RecursivTreeItem = ({ treeItem, sameDepthTreeNames, setTrees, setMethodTyp
   // -- 트리 클릭
 
   // 트리 우클릭
-  const handleContextMenu = (e: React.BaseSyntheticEvent) => {
+  const handleContextMenu = (e: React.BaseSyntheticEvent<MouseEvent>) => {
     e.preventDefault();
     e.stopPropagation();
     setContextEvent(e);

--- a/components/tree/modules/treeContext.tsx
+++ b/components/tree/modules/treeContext.tsx
@@ -20,11 +20,12 @@ interface Props {
   isShow: boolean;
   hide(): void;
   targetTree: Tree
+  mousePosition: { left: number, top: number };
   clickCreate(tree: Tree): void;
   clickRename(tree: Tree): void;
   afterDelete(tree: Tree): void;
 }
-const TreeContext = ({ anchorEl, isShow, hide, targetTree, afterDelete, clickCreate, clickRename }: Props) => {
+const TreeContext = ({ anchorEl, isShow, hide, targetTree, mousePosition, afterDelete, clickCreate, clickRename }: Props) => {
   const [deleteTargetTree, setDeleteTargetTree] = useState<Tree>();
   const [isReadyToDelete, setIsReadyToDelete] = useState<boolean>(false);
 
@@ -114,6 +115,8 @@ const TreeContext = ({ anchorEl, isShow, hide, targetTree, afterDelete, clickCre
         <Popover
           id={String(targetTree?.treeId)}
           open={isShow}
+          anchorReference={!checkInitalTree(targetTree) ? "anchorEl" : "anchorPosition"}
+          anchorPosition={{ left: mousePosition.left, top: mousePosition.top }}
           anchorEl={anchorEl}
           onClose={hide}
           anchorOrigin={{

--- a/components/tree/sections/drawerSection.tsx
+++ b/components/tree/sections/drawerSection.tsx
@@ -49,18 +49,21 @@ const DrawerSection = ({ open, drawerWidth, setFiles, handleTreeClick, handleTre
   // 컨텍스트
   const [contextEvent, setContextEvent] = useState<React.BaseSyntheticEvent<MouseEvent> | null>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [mousePosition, setMousePosition] = useState({ left: 0, top: 0 });
 
   const handleContextMenuForDrawer = (e: React.BaseSyntheticEvent<MouseEvent>) => {
     e.preventDefault();
     e.stopPropagation();
     setAnchorEl(e.target);
     setMethodTargetTree(InitialTree);
+    setMousePosition({ left: e.nativeEvent.clientX, top: e.nativeEvent.clientY });
   }
 
   const handleContextMenuForTreeItem = (e: React.BaseSyntheticEvent<MouseEvent>) => {
     e.preventDefault();
     e.stopPropagation();
     setAnchorEl(e.target);
+    setMousePosition({ left: 0, top: 0 });
   }
 
   const handleClosePopup = () => {
@@ -158,6 +161,7 @@ const DrawerSection = ({ open, drawerWidth, setFiles, handleTreeClick, handleTre
           isShow={Boolean(anchorEl)}
           hide={handleClosePopup}
           targetTree={methodTargetTree}
+          mousePosition={mousePosition}
           clickCreate={clickCreateForContext}
           clickRename={clickRenameForContext}
           afterDelete={afterDeleteForContext}

--- a/components/tree/sections/drawerSection.tsx
+++ b/components/tree/sections/drawerSection.tsx
@@ -47,17 +47,17 @@ const DrawerSection = ({ open, drawerWidth, setFiles, handleTreeClick, handleTre
   }
 
   // 컨텍스트
-  const [contextEvent, setContextEvent] = useState<React.BaseSyntheticEvent | null>(null);
+  const [contextEvent, setContextEvent] = useState<React.BaseSyntheticEvent<MouseEvent> | null>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
-  const handleContextMenuForDrawer = (e: React.BaseSyntheticEvent) => {
+  const handleContextMenuForDrawer = (e: React.BaseSyntheticEvent<MouseEvent>) => {
     e.preventDefault();
     e.stopPropagation();
     setAnchorEl(e.target);
     setMethodTargetTree(InitialTree);
   }
 
-  const handleContextMenuForTreeItem = (e: React.BaseSyntheticEvent) => {
+  const handleContextMenuForTreeItem = (e: React.BaseSyntheticEvent<MouseEvent>) => {
     e.preventDefault();
     e.stopPropagation();
     setAnchorEl(e.target);


### PR DESCRIPTION
# 이슈

* #41 

# 설명

### 마우스 이벤트 타입 설정

* 마우스 이벤트가 일어나면, 이벤트 리스너의 첫 번째 인자인 event 객체에서 해당 이벤트가 발생한 위치를 `clientX`, `clientY` 프로퍼티에서 참조할 수 있음.
* 이슈에서 필요한 기능을 구현하기 위해서는 마우스 우클릭할 때이므로, 즉 onContextMenu 리스너에서 마우스 위치를 알 수 있음.
* onContextMenu(마우스 우클릭 이벤트) 이벤트의 타입은 MouseEvent.
* 기존 코드에서 이벤트의 타입을 React.BaseSyntheticEvent 로 설정해 놨는데, 해당 타입에는 `clientX`, `clientY`가 존재하지 않음.
  ```typescript
  interface BaseSyntheticEvent<E = object, C = any, T = any> {
      nativeEvent: E;
      currentTarget: C;
      target: T;
      bubbles: boolean;
      cancelable: boolean;
      defaultPrevented: boolean;
      eventPhase: number;
      isTrusted: boolean;
      preventDefault(): void;
      isDefaultPrevented(): boolean;
      stopPropagation(): void;
      isPropagationStopped(): boolean;
      persist(): void;
      timeStamp: number;
      type: string;
  }
  ```
* 위의 BaseSyntheticEvent 타입을 보면 제네릭 E에 특정 이벤트 타입을 명시해주면 nativeEvent에서 명시한 이벤트 타입을 참조할 수 있음. 따라서 `React.BaseSyntheticEvent<MouseEvent>` 라고 하면 `event.nativeEvent.clientX` 프로퍼티에서 이벤트가 발생한 위치를 수 있음.

### `<Popover />` 컴포넌트

* MUI의 Popover 컴포넌트는 기본적으로 anchorEl (기준이 되는 엘리먼트) 를 기준으로 팝오버의 위치를 잡도록 되어 있음.
* 사용자가 지정한 위치에 Popover 컴포넌트를 보이기 위해서는 anchorReference(default는 "anchorEl")의 값이 "anchorPosition" 이 되도록 해야하고, anchorPosition에 팝오버를 렌더링 하고 싶은 위치를 지정해야 함.
  ```typescript
  <Popover
    // ...
    anchorReference="anchorPosition"
    anchorPosition={{ left: 300, top: 500 }}
    // ...
  >
  ```
* InitialTree 인지 아닌지를 판별하는 메서드인 `checkInitalTree()` 를 이용하여, InitialTree가 아니라면 anchorEl의 위치값을 참조하도록 anchorReference가 "anchorEl" 되도록 하고, InitialTree라면 사용자가 지정한 위치(마우스 우클릭이 발생한 위치)에 팝오버가 렌더링 되도록 함.
  ```typescript
  <Popover
    // ...
    anchorReference={!checkInitalTree(targetTree) ? "anchorEl" : "anchorPosition"}
    anchorPosition={{ left: mousePosition.left, top: mousePosition.top }}
    anchorEl={anchorEl}
    onClose={hide}
    anchorOrigin={{
      vertical: 'bottom',
      horizontal: 'left',
    }}
  >
  ```

## References
* [MUI Popover API Document](https://mui.com/material-ui/api/popover/)
* [onContextMenu Type?](https://felixgerschau.com/react-typescript-oncontextmenu-event-type/)