### PR TITLE
[트리] 폴더명 수정 시 하위 목록이 삭제되는 오류 fix

### DIFF
--- a/components/tree/modules/recursivTreeItem.tsx
+++ b/components/tree/modules/recursivTreeItem.tsx
@@ -44,6 +44,7 @@ const RecursivTreeItem = ({ treeItem, sameDepthTreeNames, setTrees, setMethodTyp
   const [isShowChildrenTree, setIsShowChildrenTree] = useState<boolean>(false);
 
   const handleTreeClickItem = () => {
+    if (isTreeNameEditable) return;
     treeData.treeType === TreeType.FORDER && setIsShowChildrenTree(show => !show);
     setMethod(MethodTypeForRecursivTreeItem.CLICK, treeData);
   }

--- a/components/tree/modules/recursivTreeItem.tsx
+++ b/components/tree/modules/recursivTreeItem.tsx
@@ -179,7 +179,7 @@ const RecursivTreeItem = ({ treeItem, sameDepthTreeNames, setTrees, setMethodTyp
 
   // 기존 트리 이름 수정
   const [isReadyToRename, setIsReadyToRename] = useState<boolean>(false);
-  const updateTree = useMutation(async () => await ApiHandler.callApi(ApiName.UPDATE_TREE, null, { ...treeData, userId: TEST_USER_ID, }, treeData.treeId), {
+  const updateTree = useMutation(async () => await ApiHandler.callApi(ApiName.UPDATE_TREE, null, { treeStatus: treeData.treeStatus, treeName: treeData.treeName, userId: TEST_USER_ID, }, treeData.treeId), {
     onSuccess(res: AxiosResponse) {
       handleAfterRename();
     },

--- a/components/tree/modules/recursivTreeItem.tsx
+++ b/components/tree/modules/recursivTreeItem.tsx
@@ -180,7 +180,7 @@ const RecursivTreeItem = ({ treeItem, sameDepthTreeNames, setTrees, setMethodTyp
 
   // 기존 트리 이름 수정
   const [isReadyToRename, setIsReadyToRename] = useState<boolean>(false);
-  const updateTree = useMutation(async () => await ApiHandler.callApi(ApiName.UPDATE_TREE, null, { treeStatus: treeData.treeStatus, treeName: treeData.treeName, userId: TEST_USER_ID, }, treeData.treeId), {
+  const updateTree = useMutation(async () => await ApiHandler.callApi(ApiName.UPDATE_TREE, null, { ...treeData, userId: TEST_USER_ID, }, treeData.treeId), {
     onSuccess(res: AxiosResponse) {
       handleAfterRename();
     },

--- a/components/tree/modules/treeContext.tsx
+++ b/components/tree/modules/treeContext.tsx
@@ -9,7 +9,7 @@ import { AxiosResponse } from "axios";
 import { useMutation } from "@tanstack/react-query";
 import LodingBackDrop from "@/components/common/atoms/lodingBackDrop";
 import { useEffect, useState } from "react";
-import { validateDeleteTree, validateRenameTree } from "@/src/utils/tree/validation";
+import { validateDeleteTree } from "@/src/utils/tree/validation";
 import { ValidationResponse } from "@/src/models/validation.model";
 import { checkInitalTree, createTreeFullPath } from "@/src/utils/tree/treeUtil";
 

--- a/src/utils/tree/validation.ts
+++ b/src/utils/tree/validation.ts
@@ -73,8 +73,6 @@ export const validateRenameTree = (tree: Tree): ValidationResponse => {
   };
   validating: try {
     const processedTree: Tree = { ...tree, treeName: tree.treeName.trim() };
-    delete processedTree.treeContent;
-    delete processedTree.treeChildren;
 
     if (processedTree.treeId <= 0) break validating;
     if (!processedTree.treeName) break validating;


### PR DESCRIPTION
# 이슈

* #57 

# 설명

1. 이름 변경시에, validation 확인을 한다(중복된 이름이 있는지, 빈 문자열인지 등).
2. validation 조건을 통과한 후, 현재 수정중인 Tree 객체의 정보를 변경(e.g. 공백제거)하는데, 이 때, treeChildren 프로퍼티도 같이 제거되어서 렌더링이 되지 않는다.

```typescript
// RecursiveTreeItem.ts

const handlBlurNewTreeInput = () => {
  if (treeData.treeStatus === TreeStatusInfo.CREATE) {
    // ...
  } else if (treeData.treeStatus === TreeStatusInfo.RENAME) { // (1). Tree를 수정할 경우
    if (checkEmptyTreeName()) {  // (2) 빈 문자열인지 확인
      // ...
    } else if (checkValidTreeName()) { // (3) 중복된 이름이 존재하는지 확인
      checkReadyToRename(); // (4) Tree 객체 변경
    }
  }
}

const checkReadyToRename = () => {
  const response: ValidationResponse = validateRenameTree(treeData);
  // (5) 변경한 Tree 객체를 리렌더링
  setTreeData(response.processedData)
  setIsReadyToRename(response.isValid);
}
```
```typescript
// validation.ts

export const validateRenameTree = (tree: Tree): ValidationResponse => {
  const response: ValidationResponse = {
    isValid: false,
    processedData: tree,
  };
  validating: try {
    const processedTree: Tree = { ...tree, treeName: tree.treeName.trim() };
    // 문제가 되는 부분. Tree 객체의 treeChildren 프로퍼티를 제거하기 때문에, 이름 변경시 하위 목록이 삭제되는 것처럼 보임.
    // treeContent 부분도 논리적으로 이름 변경할 때 제거되면 안되므로, 아래 두 줄을 제거하였음.
    delete processedTree.treeContent;
    delete processedTree.treeChildren;

    if (processedTree.treeId <= 0) break validating;
    if (!processedTree.treeName) break validating;

    processedTree.treeStatus = TreeStatusInfo.RENAME;

    response.isValid = true;
    response.processedData = processedTree;
  } catch (err) {
    throw err;
  }

  return response;
};
```